### PR TITLE
Fix link text typo (sos-bash)

### DIFF
--- a/running.html
+++ b/running.html
@@ -388,7 +388,7 @@ server</a> from which you can open our sample notebooks and create your own note
 <p><strong> SoS Notebook </strong></p>
 <ul>
 <li><a href="https://pypi.python.org/pypi/sos-notebook/"><strong><code>sos-notebook</code></strong></a>: Core sos-notebook module</li>
-<li><a href="https://pypi.python.org/pypi/sos-bash/"><strong><code>sos-notebook</code></strong></a>: SoS extension for shell scripts</li>
+<li><a href="https://pypi.python.org/pypi/sos-bash/"><strong><code>sos-bash</code></strong></a>: SoS extension for shell scripts</li>
 <li><a href="https://pypi.python.org/pypi/sos-javascript"><strong><code>sos-javascript</code></strong></a>: SoS extension for <code>JavaScript</code> and <code>Node.js</code></li>
 <li><a href="https://pypi.python.org/pypi/sos-julia/"><strong><code>sos-julia</code></strong></a>: SoS extension for <code>Julia</code></li>
 <li><a href="https://pypi.python.org/pypi/sos-matlab/"><strong><code>sos-matlab</code></strong></a>: SoS extension for <code>MATLAB</code> and <code>Octave</code></li>


### PR DESCRIPTION
Hi, there's a typo on the website.

The link to sos-bash is labeled sos-notebook.

See pull request below...

Best wishes